### PR TITLE
WIP: Refactor to the official carml cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
   "homepage": "https://github.com/zazuko/barnard59-carml",
   "dependencies": {
     "@rdfjs/parser-n3": "^1.1.4",
-    "duplexify": "^4.1.1",
+    "duplexify": "^4.1.2",
     "get-stream": "^6.0.1",
-    "node-fetch": "^2.6.1",
-    "rdf-ext": "^1.3.1",
+    "node-fetch": "^2.6.7",
+    "rdf-ext": "^1.3.5",
     "readable-stream": "^3.6.0",
-    "tmp-promise": "^3.0.2"
+    "tmp-promise": "^3.0.3"
   },
   "devDependencies": {
     "@rdfjs/namespace": "^1.1.0",
-    "c8": "^7.7.2",
+    "c8": "^7.12.0",
     "isstream": "^0.1.2",
     "mocha": "^8.4.0",
-    "standard": "^16.0.3"
+    "standard": "^16.0.4"
   }
 }

--- a/test/support/simple.carml.ttl
+++ b/test/support/simple.carml.ttl
@@ -7,7 +7,7 @@ PREFIX rr: <http://www.w3.org/ns/r2rml#>
 <root>
   rml:logicalSource [
     rml:source [ a carml:Stream;
-      carml:streamName "stdin"
+      carml:streamName ""
     ];
     rml:referenceFormulation ql:XPath;
     rml:iterator "/root"

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -92,8 +92,8 @@ describe('transform', () => {
       await getStream.array(stream)
     }, err => {
       strictEqual(err.message.includes('carml'), true)
-      strictEqual(err.message.includes('code'), true)
-      strictEqual(err.message.includes('Exception in'), true)
+      strictEqual(err.message.includes('CarmlJarException'), true)
+      strictEqual(err.message.includes('Exception'), true)
 
       return true
     })

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -91,6 +91,7 @@ describe('transform', () => {
     await rejects(async () => {
       await getStream.array(stream)
     }, err => {
+      console.log(err.message)
       strictEqual(err.message.includes('carml'), true)
       strictEqual(err.message.includes('CarmlJarException'), true)
       strictEqual(err.message.includes('Exception'), true)

--- a/transform.js
+++ b/transform.js
@@ -10,6 +10,8 @@ const temp = require('./lib/temp.js')
 function carmlCli ({ mappingFile, onError }) {
   const carml = spawn('java', [
     '-jar', transform.jar,
+    'map',
+    '--format=ttl',
     '-m', mappingFile,
     '-of', 'nt'
   ])
@@ -47,7 +49,7 @@ async function transform ({ mapping, mappingFile }) {
   return stream
 }
 
-transform.jarUrl = new URL('https://github.com/netage/carml-cli/releases/download/cli-1.1.1/cli-1.1.1-SNAPSHOT-jar-with-dependencies.jar')
+transform.jarUrl = new URL('http://ktk.netlabs.org/misc/rdf/carml-jar-1.0.0-SNAPSHOT-0.4.4.jar')
 transform.jar = resolve(__dirname, './carml-cli.jar')
 
 module.exports = transform


### PR DESCRIPTION
This refactors the barnard59-module to the new cli from [carml itself](https://github.com/carml/carml-jar):

- adjust download (WIP, should switch to their releases once they are [done](https://github.com/carml/carml-jar/issues/51))
- adjust test mapping file which needs to be slightly different
- update minor dependencies
- checked tests

Todo:

- [x] one test fails: `should handle transform errors`, I need support here @bergos, not sure what I have to adjust
- [ ] if I do major-depdencies updates I get ESM errors, do we have to switch the whole thing to ESM? If so I need support for that.